### PR TITLE
markdown_changelog github compare link update

### DIFF
--- a/neovim/.config/nvim/ftplugin/markdown_changelog.vim
+++ b/neovim/.config/nvim/ftplugin/markdown_changelog.vim
@@ -7,7 +7,7 @@ function! s:insert_unreleased()
   let l:version = substitute(l:version, "\n", "", "")
   let l:repopattern = '^## \[[^]]*\](\/\/\(github.com\/.*\)\/compare.*'
   let l:repo = substitute(getline(search(l:repopattern, "nW")), l:repopattern, '\1', "")
-  call append(line("."), "## [Unreleased](//".l:repo. "/compare/". l:version ."..HEAD)")
+  call append(line("."), "## [Unreleased](//".l:repo. "/compare/". l:version ."...master)")
 endfunction
 
 command! -buffer Unreleased call <SID>insert_unreleased()


### PR DESCRIPTION
- Fix link itself by using ...
- Make link more specific by using master instead of HEAD

Note I have not tested this as not using this plugin yet, but seems like it will likely work.